### PR TITLE
fix: polar.reflect('x').invert

### DIFF
--- a/__tests__/unit/polar-spec.ts
+++ b/__tests__/unit/polar-spec.ts
@@ -168,6 +168,10 @@ describe('Polar', function() {
     point = coord.convert(point);
     expect(point.x).toBe(50);
     expect(point.y).toBe(150);
+    point = coord.invert(point);
+    // 0.24999999999999997
+    expect(point.x).toBeCloseTo(0.25);
+    expect(point.y).toBe(0.5);
     coord.reflect('x');
   });
 
@@ -180,6 +184,9 @@ describe('Polar', function() {
     point = coord.convert(point);
     expect(point.x).toBe(50);
     expect(point.y).toBe(150);
+    point = coord.invert(point);
+    expect(point.x).toBe(0.75);
+    expect(point.y).toBe(0.5);
     coord.reflect('y');
   });
 

--- a/src/coord/polar.ts
+++ b/src/coord/polar.ts
@@ -103,20 +103,25 @@ export default class Polar extends Coordinate {
     const center = this.getCenter();
     const vPoint: Vector2 = [point.x - center.x, point.y - center.y];
 
+    let {startAngle, endAngle} = this;
+    if (this.isReflect('x')) {
+      [startAngle, endAngle] = [endAngle, startAngle];
+    }
+
     const m: Matrix3 = [1, 0, 0, 0, 1, 0, 0, 0, 1];
-    ext.leftRotate(m, m, this.startAngle);
+    ext.leftRotate(m, m, startAngle);
 
     const vStart3: Vector3 = [1, 0, 0];
     vec3.transformMat3(vStart3, vStart3, m);
     const vStart2: Vector2 = [vStart3[0], vStart3[1]];
-    let angle = ext.angleTo(vStart2, vPoint, this.endAngle < this.startAngle);
+    let angle = ext.angleTo(vStart2, vPoint, endAngle < startAngle);
     if (isNumberEqual(angle, Math.PI * 2)) {
       angle = 0;
     }
     const radius = vec2.length(vPoint);
 
-    let xPercent = angle / (this.endAngle - this.startAngle);
-    xPercent = this.endAngle - this.startAngle > 0 ? xPercent : -xPercent;
+    let xPercent = angle / (endAngle - startAngle);
+    xPercent = endAngle - startAngle > 0 ? xPercent : -xPercent;
 
     const yPercent = this.invertDim(radius, 'y');
     const rst = { x: 0, y: 0 };


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

Given:
```
const coord = new Polar({
  start: {
    x: 0,
    y: 300,
  },
  end: {
    x: 200,
    y: 0,
  },
});
coord.reflect('x');
```

Before fix:
```
coord.convert({ x: 0.25, y: 0.5 });  // { x: 50, y: 150 }
coord.invert({ x: 50, y: 150 });  // { x: 0.75, y: 0.5 }
```

After fix:
```
coord.convert({ x: 0.25, y: 0.5 });  // { x: 50, y: 150 }
coord.invert({ x: 50, y: 150 });  // { x: 0.24999999999999997, y: 0.5 }
```
