### PR TITLE
feat: add basic methods for coordinate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cSpell.words": [
+    "coord",
+    "recoordinate"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,21 @@ $ npm install @antv/coord
 ## 🔨 Getting Started
 
 ```ts
-// TO DO
+import { Coordinate, Options } from '@antv/coord';
+
+const optons: Options = {
+  x: 0,
+  y: 0,
+  width: 500,
+  height: 500,
+  transforms: [['scale', 10, 10]]
+}
+
+const coord = new Coordinate(options);
+coord.transform('translate', 10, 10);
+coord.map([0.5, 0.5]);
+coord.getSize();
+coord.getCenter();
 ```
 
 ## 📎 Links

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Toolkit for mapping elements of sets into geometric objects.
 
-[![Build Status](https://github.com/antvis/coord/workflows/build/badge.svg?branch=master)](https://github.com/antvis/scale/actions)
-[![Coverage Status](https://img.shields.io/coveralls/github/antvis/coord/master.svg)](https://coveralls.io/github/antvis/scale?branch=master)
-[![npm Version](https://img.shields.io/npm/v/@antv/coord.svg)](https://www.npmjs.com/package/@antv/scale)
-[![npm Download](https://img.shields.io/npm/dm/@antv/coord.svg)](https://www.npmjs.com/package/@antv/scale)
-[![npm License](https://img.shields.io/npm/l/@antv/coord.svg)](https://www.npmjs.com/package/@antv/scale)
+[![Build Status](https://github.com/antvis/coord/workflows/build/badge.svg?branch=master)](https://github.com/antvis/coord/actions)
+[![Coverage Status](https://img.shields.io/coveralls/github/antvis/coord/master.svg)](https://coveralls.io/github/antvis/coord?branch=master)
+[![npm Version](https://img.shields.io/npm/v/@antv/coord.svg)](https://www.npmjs.com/package/@antv/coord)
+[![npm Download](https://img.shields.io/npm/dm/@antv/coord.svg)](https://www.npmjs.com/package/@antv/coord)
+[![npm License](https://img.shields.io/npm/l/@antv/coord.svg)](https://www.npmjs.com/package/@antv/coord)
 
 </div>
 

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -1,7 +1,0 @@
-import { version } from '../src';
-
-describe('template', () => {
-  test('export', () => {
-    expect(version).toBe('0.1.0');
-  });
-});

--- a/__tests__/unit/coordinate.spec.ts
+++ b/__tests__/unit/coordinate.spec.ts
@@ -1,0 +1,64 @@
+import { Coordinate, Options } from '../../src';
+
+describe('Coordinate', () => {
+  test('new Coordinate() has expected defaults', () => {
+    const coord = new Coordinate();
+
+    // @ts-ignore
+    expect(coord.options).toEqual({
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 150,
+      transforms: [],
+    });
+  });
+
+  test('new Coordinate(options) override defaults', () => {
+    const options: Options = {
+      x: 10,
+      y: 20,
+      width: 200,
+      height: 100,
+      transforms: [['scale', 10, 10]],
+    };
+    const coord = new Coordinate(options);
+
+    // @ts-ignore
+    expect(coord.options).toEqual(options);
+
+    // @ts-ignore
+    expect(coord.options).not.toBe(options);
+  });
+
+  test('coord.update() updates options', () => {
+    const coord = new Coordinate();
+    coord.update({
+      x: 10,
+    });
+    expect(coord.getOptions().x).toBe(10);
+  });
+
+  test('coord.getOptions() returns the reference for options', () => {
+    const coord = new Coordinate();
+    // @ts-ignore
+    expect(coord.getOptions()).toBe(coord.options);
+  });
+
+  test('coord.clone() returns same but independent coordinate', () => {
+    const coord1 = new Coordinate();
+    const coord2 = coord1.clone();
+    expect(coord2).toBeInstanceOf(Coordinate);
+    expect(coord1.getOptions()).toEqual(coord2.getOptions());
+    expect(coord1.getOptions()).not.toBe(coord2.getOptions());
+  });
+
+  test('coord.clear() clears transforms', () => {
+    const coord = new Coordinate({
+      transforms: [['scale', 10, 10]],
+    });
+
+    coord.clear();
+    expect(coord.getOptions().transforms).toEqual([]);
+  });
+});

--- a/__tests__/unit/coordinate.spec.ts
+++ b/__tests__/unit/coordinate.spec.ts
@@ -1,11 +1,16 @@
 import { Coordinate, Options } from '../../src';
 
 describe('Coordinate', () => {
+  test('coord.getOptions() returns the reference for options', () => {
+    const coord = new Coordinate();
+    // @ts-ignore
+    expect(coord.getOptions()).toBe(coord.options);
+  });
+
   test('new Coordinate() has expected defaults', () => {
     const coord = new Coordinate();
 
-    // @ts-ignore
-    expect(coord.options).toEqual({
+    expect(coord.getOptions()).toEqual({
       x: 0,
       y: 0,
       width: 300,
@@ -36,12 +41,6 @@ describe('Coordinate', () => {
       x: 10,
     });
     expect(coord.getOptions().x).toBe(10);
-  });
-
-  test('coord.getOptions() returns the reference for options', () => {
-    const coord = new Coordinate();
-    // @ts-ignore
-    expect(coord.getOptions()).toBe(coord.options);
   });
 
   test('coord.clone() returns same but independent coordinate', () => {

--- a/__tests__/unit/coordinate.spec.ts
+++ b/__tests__/unit/coordinate.spec.ts
@@ -10,7 +10,7 @@ describe('Coordinate', () => {
       y: 0,
       width: 300,
       height: 150,
-      transforms: [],
+      transformations: [],
     });
   });
 
@@ -20,13 +20,12 @@ describe('Coordinate', () => {
       y: 20,
       width: 200,
       height: 100,
-      transforms: [['scale', 10, 10]],
+      transformations: [['scale', 10, 10]],
     };
     const coord = new Coordinate(options);
 
     // @ts-ignore
     expect(coord.options).toEqual(options);
-
     // @ts-ignore
     expect(coord.options).not.toBe(options);
   });
@@ -55,10 +54,10 @@ describe('Coordinate', () => {
 
   test('coord.clear() clears transforms', () => {
     const coord = new Coordinate({
-      transforms: [['scale', 10, 10]],
+      transformations: [['scale', 10, 10]],
     });
 
     coord.clear();
-    expect(coord.getOptions().transforms).toEqual([]);
+    expect(coord.getOptions().transformations).toEqual([]);
   });
 });

--- a/package.json
+++ b/package.json
@@ -70,12 +70,12 @@
   "limit-size": [
     {
       "path": "dist/template.min.js",
-      "limit": "500b",
+      "limit": "1.5 Kb",
       "gzip": true
     },
     {
       "path": "dist/template.min.js",
-      "limit": "1 Kb"
+      "limit": "3 Kb"
     }
   ],
   "husky": {

--- a/package.json
+++ b/package.json
@@ -94,5 +94,8 @@
   },
   "bugs": {
     "url": "https://github.com/antvis/template/issues"
+  },
+  "dependencies": {
+    "@antv/util": "^2.0.13"
   }
 }

--- a/src/coordinate.ts
+++ b/src/coordinate.ts
@@ -10,7 +10,7 @@ export class Coordinate {
       y: 0,
       width: 300,
       height: 150,
-      transforms: [],
+      transformations: [],
     };
     this.update(options);
   }
@@ -29,7 +29,7 @@ export class Coordinate {
 
   public clear() {
     this.update({
-      transforms: [],
+      transformations: [],
     });
   }
 }

--- a/src/coordinate.ts
+++ b/src/coordinate.ts
@@ -1,0 +1,35 @@
+import { deepMix } from '@antv/util';
+import { Options } from './type';
+
+export class Coordinate {
+  private options: Options;
+
+  constructor(options?: Partial<Options>) {
+    this.options = {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 150,
+      transforms: [],
+    };
+    this.update(options);
+  }
+
+  public update(options: Partial<Options>) {
+    this.options = deepMix({}, this.options, options);
+  }
+
+  public clone() {
+    return new Coordinate(this.options);
+  }
+
+  public getOptions() {
+    return this.options;
+  }
+
+  public clear() {
+    this.update({
+      transforms: [],
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export const version = '0.1.0';
+export type { Options } from './type';
+export { Coordinate } from './coordinate';

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,11 +1,11 @@
 type Translate = ['translate', number, number];
 type Scale = ['scale', number, number];
-export type Transform = Translate | Scale;
+export type Transformation = Translate | Scale;
 
 export type Options = {
   x?: number;
   y?: number;
   width?: number;
   height?: number;
-  transforms?: Transform[];
+  transformations?: Transformation[];
 };

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,0 +1,11 @@
+type Translate = ['translate', number, number];
+type Scale = ['scale', number, number];
+export type Transform = Translate | Scale;
+
+export type Options = {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  transforms?: Transform[];
+};


### PR DESCRIPTION
实现了以下最基础的方法：

- constructor()
- update()
- clone()
- getOptions()
- clear()

这里提供了两种指定 transforms 的方式：

```ts
// 第一种
const coord = new Coordinate({
  transformations: [['scale', 10, 10]]
})

// 第二种
const coord = new Coordinate();
coord.transform('scale', 10, 10);
```
