### PR TITLE
Fix/parallel

### DIFF
--- a/__tests__/unit/transforms/parallel.spec.ts
+++ b/__tests__/unit/transforms/parallel.spec.ts
@@ -6,7 +6,7 @@ describe('Parallel', () => {
     coord.transform('parallel', 0, 1, 0, 1);
 
     const from: Vector = [0.5, 0.3, 0.2, 0.4];
-    const to: Vector = [0, 0.5, 0.25, 0.3, 0.5, 0.2, 0.75, 0.4, 1, 0.5];
+    const to: Vector = [0, 0.5, 0.25, 0.3, 0.5, 0.2, 0.75, 0.4];
     expect(coord.map(from)).toEqual(to);
     expect(coord.invert(to)).toEqual(from);
   });
@@ -17,7 +17,7 @@ describe('Parallel', () => {
     coord.transform('cartesian');
     coord.transform('translate', 10, 5);
 
-    expect(coord.map([0.5, 0.3, 0.2, 0.4])).toEqual([10, 80, 85, 50, 160, 35, 235, 65, 310, 80]);
-    expect(coord.invert([10, 80, 85, 50, 160, 35, 235, 65, 310, 80])).toEqual([0.5, 0.3, 0.2, 0.4]);
+    expect(coord.map([0.5, 0.3, 0.2, 0.4])).toEqual([10, 80, 85, 50, 160, 35, 235, 65]);
+    expect(coord.invert([10, 80, 85, 50, 160, 35, 235, 65])).toEqual([0.5, 0.3, 0.2, 0.4]);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/coord",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Toolkit for mapping elements of sets into geometric objects.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/transforms/parallel.ts
+++ b/src/transforms/parallel.ts
@@ -30,14 +30,11 @@ export const parallel: CreateTransformer = (params, x, y, width, height) => {
         const y = sy.map(e);
         v.push(x, y);
       }
-
-      // 将第一个点加在最后
-      v.push(1, v[1]);
       return v;
     },
     untransform(vector: Vector) {
       const v = [];
-      for (let i = 0; i < vector.length - 2; i += 2) {
+      for (let i = 0; i < vector.length; i += 2) {
         const y = vector[i + 1];
         v.push(sy.invert(y));
       }


### PR DESCRIPTION
Do not append first line of points to the end.

![image](https://user-images.githubusercontent.com/49330279/160058398-5ad8331d-b26b-4522-a67e-4818aaec63d0.png)

 It should specify explicitly.

```js
// before
const position = [
  'Cylinders',
  'Displacement',
  'Weight_in_lbs',
  'Horsepower',
  'Acceleration',
  'Miles_per_Gallon',
  'Year',
];
```
```js
// after
const position = [
  'Cylinders',
  'Displacement',
  'Weight_in_lbs',
  'Horsepower',
  'Acceleration',
  'Miles_per_Gallon',
  'Year',
  'Cylinders', // Append first line of points to the end.
];
```