### PR TITLE
Fix/parallel

### DIFF
--- a/__tests__/unit/transforms/parallel.spec.ts
+++ b/__tests__/unit/transforms/parallel.spec.ts
@@ -5,8 +5,8 @@ describe('Parallel', () => {
     const coord = new Coordinate();
     coord.transform('parallel', 0, 1, 0, 1);
 
-    const from: Vector = [0.5, 0.3, 0.2, 0.4];
-    const to: Vector = [0, 0.5, 0.25, 0.3, 0.5, 0.2, 0.75, 0.4];
+    const from: Vector = [0.5, 0.3, 0.2, 0.4, 0.1];
+    const to: Vector = [0, 0.5, 0.25, 0.3, 0.5, 0.2, 0.75, 0.4, 1, 0.1];
     expect(coord.map(from)).toEqual(to);
     expect(coord.invert(to)).toEqual(from);
   });
@@ -17,7 +17,7 @@ describe('Parallel', () => {
     coord.transform('cartesian');
     coord.transform('translate', 10, 5);
 
-    expect(coord.map([0.5, 0.3, 0.2, 0.4])).toEqual([10, 80, 85, 50, 160, 35, 235, 65]);
-    expect(coord.invert([10, 80, 85, 50, 160, 35, 235, 65])).toEqual([0.5, 0.3, 0.2, 0.4]);
+    expect(coord.map([0.5, 0.3, 0.2, 0.4, 0.1])).toEqual([10, 80, 85, 50, 160, 35, 235, 65, 310, 20]);
+    expect(coord.invert([10, 80, 85, 50, 160, 35, 235, 65, 310, 20])).toEqual([0.5, 0.3, 0.2, 0.4, 0.1]);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/coord",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Toolkit for mapping elements of sets into geometric objects.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/coordinate.ts
+++ b/src/coordinate.ts
@@ -109,7 +109,7 @@ export class Coordinate {
    * Returns the size of the bounding box of the coordinate.
    * @returns [width, height]
    */
-  public getSize() {
+  public getSize(): [number, number] {
     const { width, height } = this.options;
     return [width, height];
   }
@@ -118,7 +118,7 @@ export class Coordinate {
    * Returns the center of the bounding box of the coordinate.
    * @returns [centerX, centerY]
    */
-  public getCenter() {
+  public getCenter(): [number, number] {
     const { x, y, width, height } = this.options;
     return [(x * 2 + width) / 2, (y * 2 + height) / 2];
   }

--- a/src/transforms/parallel.ts
+++ b/src/transforms/parallel.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Linear, Band } from '@antv/scale';
+import { Linear, Point } from '@antv/scale';
 import { CreateTransformer, Vector } from '../type';
 
 /**
@@ -20,7 +20,7 @@ export const parallel: CreateTransformer = (params, x, y, width, height) => {
     transform(vector: Vector) {
       const v = [];
       const len = vector.length;
-      const sx = new Band({
+      const sx = new Point({
         domain: new Array(len).fill(0).map((_, i) => i),
         range: [x0, x1],
       });


### PR DESCRIPTION
Use point scale instead of band scale to calc x for each points. This can eliminate the blank in the right part of canvas.

| Before      |After  |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/49330279/160066085-9384410e-ab2f-4f97-8c59-302eab25b2ca.png)    | ![image](https://user-images.githubusercontent.com/49330279/160065891-247dc035-6ef3-4718-8afb-fbb86e950a21.png)     |






