### PR TITLE
feat: fisheye accepts abstract focus point instead of visual focus point

### DIFF
--- a/__tests__/unit/transforms/fisheye.spec.ts
+++ b/__tests__/unit/transforms/fisheye.spec.ts
@@ -74,10 +74,9 @@ describe('Fisheye', () => {
   });
 
   test('fisheye.circular() ignores vector2 outside the circle', () => {
-    const coord = new Coordinate({
-      transformations: [['cartesian']],
-    });
-    coord.transform('fisheye.circular', 150, 75, 30, 2);
+    const coord = new Coordinate();
+    coord.transform('fisheye.circular', 0.5, 0.5, 30, 2);
+    coord.transform('cartesian');
 
     expect(coord.map([0.5, 0.29])).toEqual([150, 43.5]);
     expect(coord.map([0.5, 0.71])).toEqual([150, 106.5]);
@@ -90,10 +89,9 @@ describe('Fisheye', () => {
   });
 
   test('fisheye.circular() applies circular transformations for vector2 inside the circle', () => {
-    const coord = new Coordinate({
-      transformations: [['cartesian']],
-    });
-    coord.transform('fisheye.circular', 150, 75, 30, 2);
+    const coord = new Coordinate();
+    coord.transform('fisheye.circular', 0.5, 0.5, 30, 2);
+    coord.transform('cartesian');
 
     let from = [0.45, 0.45];
     let to = coord.map(from);
@@ -104,6 +102,15 @@ describe('Fisheye', () => {
     from = [0.55, 0.55];
     to = coord.map(from);
     expect(to).toEqual([171.24611797498108, 85.62305898749054]);
+    expect(coord.invert(to)[0]).toBeCloseTo(from[0]);
+    expect(coord.invert(to)[1]).toBeCloseTo(from[1]);
+
+    coord.clear();
+    coord.transform('fisheye.circular', 150, 75, 30, 2, true);
+    coord.transform('cartesian');
+    from = [0.45, 0.45];
+    to = coord.map(from);
+    expect(to).toEqual([128.75388202501892, 64.37694101250946]);
     expect(coord.invert(to)[0]).toBeCloseTo(from[0]);
     expect(coord.invert(to)[1]).toBeCloseTo(from[1]);
   });

--- a/__tests__/unit/transforms/fisheye.spec.ts
+++ b/__tests__/unit/transforms/fisheye.spec.ts
@@ -3,26 +3,29 @@ import { Coordinate } from '../../../src';
 describe('Fisheye', () => {
   test('fisheye.x() applies cartesian fisheye transformation for the first dimension of vector2', () => {
     const coord = new Coordinate({
-      transformations: [['cartesian']],
+      transformations: [['fisheye.x', 0.5, 2], ['cartesian']],
     });
-    coord.transform('fisheye.x', 150, 2);
 
     let from = [0.4, 0.2];
     let to = coord.map(from);
-    expect(to).toEqual([85.71428571428571, 30]);
+    expect(to).toEqual([85.71428571428572, 30]);
     expect(coord.invert(to)).toEqual(from);
 
     from = [0.7, 0.3];
     to = coord.map(from);
     expect(coord.invert(to)).toEqual(from);
+    coord.clear();
 
-    coord.transform('fisheye.x', 150, 2);
+    coord.transform('fisheye.x', 150, 2, true);
+    coord.transform('cartesian');
+
     from = [0.5, 0.3];
     to = coord.map(from);
     expect(coord.invert(to)).toEqual(from);
 
     coord.clear();
     coord.transform('fisheye.x', 0, 2);
+    coord.transform('cartesian');
     from = [-0.5, 0.3];
     to = coord.map(from);
     expect(coord.invert(to)).toEqual(from);
@@ -30,15 +33,18 @@ describe('Fisheye', () => {
 
   test('fisheye.y() applies cartesian fisheye transformation for the second dimension of vector2', () => {
     const coord = new Coordinate({
-      transformations: [['cartesian']],
+      transformations: [['fisheye.y', 0.5, 2], ['cartesian']],
     });
-    coord.transform('fisheye.y', 75, 2);
 
     let from = [0.4, 0.2];
     let to = coord.map(from);
     expect(to).toEqual([120, 13.63636363636364]);
     expect(coord.invert(to)[0]).toBeCloseTo(from[0]);
     expect(coord.invert(to)[1]).toBeCloseTo(from[1]);
+
+    coord.clear();
+    coord.transform('fisheye.y', 75, 2, true);
+    coord.transform('cartesian');
 
     from = [0.7, 0.3];
     to = coord.map(from);
@@ -48,15 +54,18 @@ describe('Fisheye', () => {
 
   test('fisheye() applies cartesian fisheye transformation for both dimensions of vector2', () => {
     const coord = new Coordinate({
-      transformations: [['cartesian']],
+      transformations: [['fisheye', 0.5, 0.5, 2, 2], ['cartesian']],
     });
-    coord.transform('fisheye', 150, 75, 2, 2);
 
     let from = [0.4, 0.2];
     let to = coord.map(from);
-    expect(to).toEqual([85.71428571428571, 13.63636363636364]);
+    expect(to).toEqual([85.71428571428572, 13.63636363636364]);
     expect(coord.invert(to)[0]).toBeCloseTo(from[0]);
     expect(coord.invert(to)[1]).toBeCloseTo(from[1]);
+
+    coord.clear();
+    coord.transform('fisheye', 150, 75, 2, 2, true);
+    coord.transform('cartesian');
 
     from = [0.7, 0.3];
     to = coord.map(from);

--- a/docs/api/transformations.md
+++ b/docs/api/transformations.md
@@ -7,9 +7,7 @@ import { Coord } from '@antv/coord';
 
 // first
 const coord1 = new Coord({
-  transformations: [
-    ['scale', 10, 10]
-  ]
+  transformations: [['scale', 10, 10]],
 });
 
 // second
@@ -174,10 +172,7 @@ import { Coordinate } from '@antv/coord';
 const coord = new Coordinate({
   width: 200,
   height: 300,
-  transformations: [
-    ['polar', -Math.PI / 2, (Math.PI * 3) / 2, 0, 1], 
-    ['cartesian']
-  ],
+  transformations: [['polar', -Math.PI / 2, (Math.PI * 3) / 2, 0, 1], ['cartesian']],
 });
 
 coord.map([0, 1]); // [100, 50]
@@ -193,13 +188,10 @@ import { Coordinate } from '@antv/coord';
 const coord = new Coordinate({
   width: 300,
   height: 300,
-  transformations: [
-    ['helix', 0, Math.PI * 6, 0, 1], 
-    ['cartesian']
-  ],
+  transformations: [['helix', 0, Math.PI * 6, 0, 1], ['cartesian']],
 });
 
-coord.map([0, 1]) // [187.5, 150]
+coord.map([0, 1]); // [187.5, 150]
 ```
 
 <a name="parallel" href="#parallel">#</a> **transform**<i>('parallel', x0: number, x1: number, y0: number, y1: number) : Coordinate</i> · [examples](https://observablehq.com/@pearmini/antv-coord#parallel)
@@ -215,50 +207,53 @@ coord.transform('cartesian');
 coord.transform('translate', 10, 5);
 
 const from: Vector = [0.5, 0.3, 0.2, 0.4];
-coord.map(from) // [10, 80, 85, 50, 160, 35, 235, 65]
+coord.map(from); // [10, 80, 85, 50, 160, 35, 235, 65]
 ```
 
 ## Fisheye Lens
 
-<a name="fisheye" href="#fisheye">#</a> **transform**<i>('fisheye', focusX: number, focusY: number, distortionX: number, distortionY: number) : Coordinate</i> · [examples](https://observablehq.com/@pearmini/antv-coord#cartesianFisheye)
+<a name="fisheye" href="#fisheye">#</a> **transform**<i>('fisheye', focusX: number, focusY: number, distortionX: number, distortionY: number, isVisual?: boolean) : Coordinate</i> · [examples](https://observablehq.com/@pearmini/antv-coord#cartesianFisheye)
 
 Applies cartesian fisheye effects for both dimensions of input vector.
 
 ```ts
 import { Coordinate } from '@antv/coord';
 
-const coord = new Coordinate({
-  transformations: [['cartesian']],
-});
-coord.transform('fisheye', 150, 75, 2, 2);
+const coord = new Coordinate();
+// The first way to declare.
+coord.transform('fisheye', 0.5, 0.5, 2, 2); // Abstract value by default.
+coord.transform('cartesian');
+
+// The second way to declare.
+coord.transform('fisheye', 300, 150, 2, 2, true); // visual value.
+coord.transform('cartesian');
+
 coord.map([0.4, 0.2]); // [85.71428571428571, 13.63636363636364]
 ```
 
-<a name="fisheye.x" href="#fisheye.x">#</a> **transform**<i>('fisheye.x', focus: number,  distortion: number) : Coordinate</i> · [examples](https://observablehq.com/@pearmini/antv-coord#cartesianFisheye)
+<a name="fisheye.x" href="#fisheye.x">#</a> **transform**<i>('fisheye.x', focus: number, distortion: number) : Coordinate</i> · [examples](https://observablehq.com/@pearmini/antv-coord#cartesianFisheye)
 
 Applies cartesian fisheye effects for the x dimensions of input vector.
 
 ```ts
 import { Coordinate } from '@antv/coord';
 
-const coord = new Coordinate({
-  transformations: [['cartesian']],
-});
-coord.transform('fisheye.x', 150, 2);
+const coord = new Coordinate();
+coord.transform('fisheye.x', 0.5, 2);
+coord.transform('cartesian');
 coord.map([0.4, 0.2]); // [85.71428571428571, 30]
 ```
 
-<a name="fisheye.y" href="#fisheye.y">#</a> **transform**<i>('fisheye.y', focus: number,  distortion: number) : Coordinate</i> · [examples](https://observablehq.com/@pearmini/antv-coord#cartesianFisheye)
+<a name="fisheye.y" href="#fisheye.y">#</a> **transform**<i>('fisheye.y', focus: number, distortion: number) : Coordinate</i> · [examples](https://observablehq.com/@pearmini/antv-coord#cartesianFisheye)
 
 Applies cartesian fisheye effects for the y dimensions of input vector.
 
 ```ts
 import { Coordinate } from '@antv/coord';
 
-const coord = new Coordinate({
-  transformations: [['cartesian']],
-});
-coord.transform('fisheye.y', 150, 2);
+const coord = new Coordinate();
+coord.transform('fisheye.y', 0.5, 2);
+coord.transform('cartesian');
 coord.map([0.4, 0.2]); // [120, 13.63636363636364]
 ```
 
@@ -269,10 +264,9 @@ Applies circular fisheye effects for input vector.
 ```ts
 import { Coordinate } from '@antv/coord';
 
-const coord = new Coordinate({
-  transformations: [['cartesian']],
-});
-coord.transform('fisheye.circular', 150, 75, 30, 2);
+const coord = new Coordinate();
+coord.transform('fisheye.circular', 0.5, 0.5, 30, 2);
+coord.transform('cartesian');
 coord.map([0.45, 0.45]); // [128.75388202501892, 64.37694101250946]
 ```
 
@@ -287,10 +281,10 @@ import { Coordinate, Transformer } from '@antv/coord';
 
 const coord = new Coordinate();
 coord.transform('custom', (x, y, width, height) => {
-  x // 0
-  y // 0
-  width // 300
-  height // 150
+  x; // 0
+  y; // 0
+  width; // 300
+  height; // 150
   return {
     transform(vector) {
       const [v1, v2] = vector;
@@ -304,7 +298,7 @@ coord.transform('custom', (x, y, width, height) => {
 });
 
 coord.map([0.5, 0.5]); // [150, 75])
-coord.invert([150, 75]) // [0.5, 0.5])
+coord.invert([150, 75]); // [0.5, 0.5])
 ```
 
 <a name="matrix" href="#matrix">#</a> **transform**<i>('matrix', matrix3: Matrix3) : Coordinate</i>

--- a/src/transforms/fisheye.ts
+++ b/src/transforms/fisheye.ts
@@ -17,15 +17,17 @@ function fisheyeUntransform(tx: number, focus: number, distortion: number, min: 
   return m / ((m * (distortion + 1)) / (tx - focus) - distortion * f) + focus;
 }
 
-function normalize(focus: number, length: number, isVisual: boolean) {
-  if (isVisual) {
-    const s = new Linear({
-      range: [0, 1],
-      domain: [0, length],
-    });
-    return s.map(focus);
-  }
-  return focus;
+/**
+ * Map actual visual point to abstract focus point(0, 1)
+ */
+function normalize(focus: number, length: number, isVisual: boolean): number {
+  if (!isVisual) return focus;
+
+  const s = new Linear({
+    range: [0, 1],
+    domain: [0, length],
+  });
+  return s.map(focus);
 }
 
 /**
@@ -38,8 +40,8 @@ function normalize(focus: number, length: number, isVisual: boolean) {
  * @returns transformer
  */
 export const fisheyeX: CreateTransformer = (params, x, y, width, height) => {
-  const [focus, distortion, isVisual = false] = params as number[];
-  const normalizedFocusX = normalize(focus, width, isVisual as boolean);
+  const [focus, distortion, isVisual = false] = params as [number, number, boolean];
+  const normalizedFocusX = normalize(focus, width, isVisual);
   return {
     transform(vector: Vector2) {
       const [vx, vy] = vector;
@@ -64,8 +66,8 @@ export const fisheyeX: CreateTransformer = (params, x, y, width, height) => {
  * @returns transformer
  */
 export const fisheyeY: CreateTransformer = (params, x, y, width, height) => {
-  const [focus, distortion, isVisual = false] = params as number[];
-  const normalizedFocusY = normalize(focus, height, isVisual as boolean);
+  const [focus, distortion, isVisual = false] = params as [number, number, boolean];
+  const normalizedFocusY = normalize(focus, height, isVisual);
 
   return {
     transform(vector: Vector2) {
@@ -91,10 +93,15 @@ export const fisheyeY: CreateTransformer = (params, x, y, width, height) => {
  * @returns transformer
  */
 export const fisheye: CreateTransformer = (params, x, y, width, height) => {
-  const [focusX, focusY, distortionX, distortionY, isVisual = false] = params as number[];
-
-  const normalizedFocusX = normalize(focusX, width, isVisual as boolean);
-  const normalizedFocusY = normalize(focusY, height, isVisual as boolean);
+  const [focusX, focusY, distortionX, distortionY, isVisual = false] = params as [
+    number,
+    number,
+    number,
+    number,
+    boolean,
+  ];
+  const normalizedFocusX = normalize(focusX, width, isVisual);
+  const normalizedFocusY = normalize(focusY, height, isVisual);
 
   return {
     transform(vector: Vector2) {
@@ -114,7 +121,7 @@ export const fisheye: CreateTransformer = (params, x, y, width, height) => {
 
 /**
  * Applies circular fisheye transforms.
- * @param params [focusX, focusY, radius, distortion]
+ * @param params [focusX, focusY, radius, distortion, isVisual?]
  * @param x x of the the bounding box of coordinate
  * @param y y of the the bounding box of coordinate
  * @param width width of the the bounding box of coordinate
@@ -122,27 +129,48 @@ export const fisheye: CreateTransformer = (params, x, y, width, height) => {
  * @returns transformer
  */
 export const fisheyeCircular: CreateTransformer = (params, x, y, width, height) => {
-  const [focusX, focusY, radius, distortion] = params as number[];
+  const [focusX, focusY, radius, distortion, isVisual = false] = params as [number, number, number, number, boolean];
+
+  const scaleX = new Linear({
+    range: [0, width],
+  });
+  const scaleY = new Linear({
+    range: [0, height],
+  });
+  // focus point => visual point
+  const nx = isVisual ? focusX : scaleX.map(focusX);
+  const ny = isVisual ? focusY : scaleY.map(focusY);
+
   return {
     transform(vector: Vector2) {
       const [x, y] = vector;
-      const dx = x - focusX;
-      const dy = y - focusY;
+      // focus point => visual point
+      const dx = scaleX.map(x) - nx;
+      const dy = scaleY.map(y) - ny;
       const dd = Math.sqrt(dx * dx + dy * dy);
+
       if (dd > radius) return [x, y];
       const r = fisheyeTransform(dd, 0, distortion, 0, radius);
       const theta = Math.atan2(dy, dx);
-      return [focusX + r * Math.cos(theta), focusY + r * Math.sin(theta)];
+
+      const fx = nx + r * Math.cos(theta);
+      const fy = ny + r * Math.sin(theta);
+      // visual point => focus point
+      return [scaleX.invert(fx), scaleY.invert(fy)];
     },
     untransform(vector: Vector2) {
       const [tx, ty] = vector;
-      const dx = tx - focusX;
-      const dy = ty - focusY;
+      const dx = scaleX.map(tx) - nx;
+      const dy = scaleY.map(ty) - ny;
       const dd = Math.sqrt(dx * dx + dy * dy);
       if (dd > radius) return [tx, ty];
+
       const x = fisheyeUntransform(dd, 0, distortion, 0, radius);
       const theta = Math.atan2(dy, dx);
-      return [focusX + x * Math.cos(theta), focusY + x * Math.sin(theta)];
+
+      const fx = nx + x * Math.cos(theta);
+      const fy = ny + x * Math.sin(theta);
+      return [scaleX.invert(fx), scaleY.invert(fy)];
     },
   };
 };

--- a/src/type.ts
+++ b/src/type.ts
@@ -20,7 +20,7 @@ type Parallel = ['parallel', number, number, number, number];
 type Fisheye = ['fisheye', number, number, number, number, boolean?];
 type FisheyeX = ['fisheye.x', number, number, boolean?];
 type FisheyeY = ['fisheye.y', number, number, boolean?];
-type FisheyeCircular = ['fisheye.circular', number, number, number, number];
+type FisheyeCircular = ['fisheye.circular', number, number, number, number, boolean?];
 
 export type Transformation =
   | Translate

--- a/src/type.ts
+++ b/src/type.ts
@@ -17,9 +17,9 @@ type ReflectY = ['reflect.y'];
 type Rotate = ['rotate', number];
 type Helix = ['helix', number, number, number, number];
 type Parallel = ['parallel', number, number, number, number];
-type Fisheye = ['fisheye', number, number, number, number];
-type FisheyeX = ['fisheye.x', number, number];
-type FisheyeY = ['fisheye.y', number, number];
+type Fisheye = ['fisheye', number, number, number, number, boolean?];
+type FisheyeX = ['fisheye.x', number, number, boolean?];
+type FisheyeY = ['fisheye.y', number, number, boolean?];
 type FisheyeCircular = ['fisheye.circular', number, number, number, number];
 
 export type Transformation =
@@ -67,7 +67,7 @@ export type Transformer = {
 };
 
 export type CreateTransformer = (
-  params: number[] | [TransformCallback] | [Matrix3],
+  params: number[] | (number | boolean)[] | [TransformCallback] | [Matrix3],
   x: number,
   y: number,
   width: number,


### PR DESCRIPTION
### Features
Fisheye position supports abstract point and actual visual point.
- [x] fisheye.x
- [x] fisheye.y
- [x] fisheye
- [x] fIsheye.circular

### API
```ts
params: {
  focusX: number;
  focusY: number;
  distortionX: number;
  distortionY: number;
  /** whether focus is visual point */
  isVisual?: boolean
}
```
### Usage
```js
const coord = new Coordinate({
  width: '150px',
  height: '300px'
});

// 1. use relative point
coord.transform('fisheye', 0.5, 0.5, 2, 2);
coord.transform('cartesian');

// 2. use visual point
coord.transform('fisheye', 100, 100, 2, 2, true);
coord.transform('cartesian');
```


### Effects

|  relative point   |  visual point  |
|  ----  | ----  |
| ![iShot_2022-08-16_18 11 08](https://user-images.githubusercontent.com/109653633/184854851-e8471578-2de6-4f4d-ae1b-96ba2b873f2e.gif) | ![iShot_2022-08-16_18 21 57](https://user-images.githubusercontent.com/109653633/184857010-bf7244d9-18b2-47dc-9b1f-5a4f8cc45c13.gif) |





