### PR TITLE
feat: support cartesian3d transform

### DIFF
--- a/__tests__/unit/coordinate.spec.ts
+++ b/__tests__/unit/coordinate.spec.ts
@@ -1,4 +1,5 @@
-import { Coordinate, Options, Vector2, Transformation } from '../../src';
+import { Coordinate, Options, Transformation } from '../../src';
+import { Vector2 } from '../../src/type';
 
 describe('Coordinate', () => {
   test('coord.getOptions() returns the reference for options', () => {
@@ -152,5 +153,28 @@ describe('Coordinate', () => {
 
     coord.clear();
     expect(coord.getOptions().transformations).toEqual([]);
+  });
+
+  test('coord.getSize() returns current size of the bounding box in 3D', () => {
+    const coord = new Coordinate({
+      width: 100,
+      height: 50,
+      depth: 100,
+      transformations: [['cartesian3D']],
+    });
+
+    expect(coord.getSize()).toEqual([100, 50, 100]);
+    expect(coord.getCenter()).toEqual([50, 25, 50]);
+    expect(coord.getOptions()).toEqual({
+      x: 0,
+      y: 0,
+      z: 0,
+      width: 100,
+      height: 50,
+      depth: 100,
+      transformations: [['cartesian3D']],
+    });
+    expect(coord.map([0, 0, 0])).toEqual([0, 0, 0]);
+    expect(coord.invert([0, 0, 0])).toEqual([0, 0, 0]);
   });
 });

--- a/__tests__/unit/coordinate.spec.ts
+++ b/__tests__/unit/coordinate.spec.ts
@@ -154,27 +154,4 @@ describe('Coordinate', () => {
     coord.clear();
     expect(coord.getOptions().transformations).toEqual([]);
   });
-
-  test('coord.getSize() returns current size of the bounding box in 3D', () => {
-    const coord = new Coordinate({
-      width: 100,
-      height: 50,
-      depth: 100,
-      transformations: [['cartesian3D']],
-    });
-
-    expect(coord.getSize()).toEqual([100, 50, 100]);
-    expect(coord.getCenter()).toEqual([50, 25, 50]);
-    expect(coord.getOptions()).toEqual({
-      x: 0,
-      y: 0,
-      z: 0,
-      width: 100,
-      height: 50,
-      depth: 100,
-      transformations: [['cartesian3D']],
-    });
-    expect(coord.map([0, 0, 0])).toEqual([0, 0, 0]);
-    expect(coord.invert([0, 0, 0])).toEqual([0, 0, 0]);
-  });
 });

--- a/__tests__/unit/coordinate3D.spec.ts
+++ b/__tests__/unit/coordinate3D.spec.ts
@@ -1,0 +1,75 @@
+import { Coordinate3D, Options, Transformation } from '../../src';
+import { Vector3 } from '../../src/type';
+
+describe('Coordinate', () => {
+  test('coord.getOptions() returns the reference for options', () => {
+    const coord = new Coordinate3D();
+    // @ts-ignore
+    expect(coord.getOptions()).toBe(coord.options);
+  });
+
+  test('cartesian3D() maps normalized value to entire bounding areas', () => {
+    const coord = new Coordinate3D({
+      transformations: [['cartesian3D']],
+      depth: 100,
+    });
+    const v1: Vector3 = [0, 0, 0];
+    const v2: Vector3 = [0, 0, 0];
+
+    expect(coord.map(v1)).toEqual(v2);
+    expect(coord.map([1, 1, 1])).toEqual([300, 150, 100]);
+    expect(coord.invert(v1)).toEqual(v2);
+    expect(coord.invert([300, 150, 100])).toEqual([1, 1, 1]);
+  });
+
+  test('cartesian3D() should use default depth & z if not provided', () => {
+    const coord = new Coordinate3D({
+      transformations: [['cartesian3D']],
+    });
+    const v1: Vector3 = [0, 0, 0];
+    const v2: Vector3 = [0, 0, 0];
+
+    expect(coord.map(v1)).toEqual(v2);
+    expect(coord.map([1, 1, 1])).toEqual([300, 150, 150]);
+  });
+
+  test('coord.getSize() returns current size of the bounding box in 3D', () => {
+    const coord = new Coordinate3D({
+      width: 100,
+      height: 50,
+      depth: 100,
+      transformations: [['cartesian3D']],
+    });
+
+    expect(coord.getSize()).toEqual([100, 50, 100]);
+    expect(coord.getCenter()).toEqual([50, 25, 50]);
+    expect(coord.getOptions()).toEqual({
+      x: 0,
+      y: 0,
+      z: 0,
+      width: 100,
+      height: 50,
+      depth: 100,
+      transformations: [['cartesian3D']],
+    });
+    expect(coord.map([0, 0, 0])).toEqual([0, 0, 0]);
+    expect(coord.invert([0, 0, 0])).toEqual([0, 0, 0]);
+  });
+
+  test('coord.clone() returns same but independent coordinate', () => {
+    const coord1 = new Coordinate3D();
+    const coord2 = coord1.clone();
+    expect(coord2).toBeInstanceOf(Coordinate3D);
+    expect(coord1.getOptions()).toEqual(coord2.getOptions());
+    expect(coord1.getOptions()).not.toBe(coord2.getOptions());
+  });
+
+  test('coord.clear() clears transforms', () => {
+    const coord = new Coordinate3D({
+      transformations: [['translate3D', 10, 10, 10]],
+    });
+
+    coord.clear();
+    expect(coord.getOptions().transformations).toEqual([]);
+  });
+});

--- a/__tests__/unit/transforms/cartesian3D.spec.ts
+++ b/__tests__/unit/transforms/cartesian3D.spec.ts
@@ -1,8 +1,21 @@
-import { Coordinate, Vector3 } from '../../../src';
+import { Coordinate3D, Vector3 } from '../../../src';
 
 describe('Cartesian3D', () => {
   test('cartesian3D() maps normalized value to entire bounding areas', () => {
-    const coord = new Coordinate({
+    const coord = new Coordinate3D({
+      transformations: [['cartesian3D']],
+    });
+    const v1: Vector3 = [0, 0, 0];
+    const v2: Vector3 = [0, 0, 0];
+
+    expect(coord.map(v1)).toEqual(v2);
+    expect(coord.map([1, 1, 1])).toEqual([300, 150, 150]);
+    expect(coord.invert([0, 0, 0])).toEqual([0, 0, 0]);
+    expect(coord.invert([300, 150, 150])).toEqual([1, 1, 1]);
+  });
+
+  test('cartesian3D() maps normalized value to entire bounding areas', () => {
+    const coord = new Coordinate3D({
       transformations: [['cartesian3D']],
       depth: 100,
     });
@@ -11,18 +24,7 @@ describe('Cartesian3D', () => {
 
     expect(coord.map(v1)).toEqual(v2);
     expect(coord.map([1, 1, 1])).toEqual([300, 150, 100]);
-    expect(coord.invert(v1)).toEqual(v2);
+    expect(coord.invert([0, 0, 0])).toEqual([0, 0, 0]);
     expect(coord.invert([300, 150, 100])).toEqual([1, 1, 1]);
-  });
-
-  test('cartesian3D() should use default depth & z if not provided', () => {
-    const coord = new Coordinate({
-      transformations: [['cartesian3D']],
-    });
-    const v1: Vector3 = [0, 0, 0];
-    const v2: Vector3 = [0, 0, 0];
-
-    expect(coord.map(v1)).toEqual(v2);
-    expect(coord.map([1, 1, 1])).toEqual([300, 150, 0]);
   });
 });

--- a/__tests__/unit/transforms/cartesian3D.spec.ts
+++ b/__tests__/unit/transforms/cartesian3D.spec.ts
@@ -1,0 +1,28 @@
+import { Coordinate, Vector3 } from '../../../src';
+
+describe('Cartesian3D', () => {
+  test('cartesian3D() maps normalized value to entire bounding areas', () => {
+    const coord = new Coordinate({
+      transformations: [['cartesian3D']],
+      depth: 100,
+    });
+    const v1: Vector3 = [0, 0, 0];
+    const v2: Vector3 = [0, 0, 0];
+
+    expect(coord.map(v1)).toEqual(v2);
+    expect(coord.map([1, 1, 1])).toEqual([300, 150, 100]);
+    expect(coord.invert(v1)).toEqual(v2);
+    expect(coord.invert([300, 150, 100])).toEqual([1, 1, 1]);
+  });
+
+  test('cartesian3D() should use default depth & z if not provided', () => {
+    const coord = new Coordinate({
+      transformations: [['cartesian3D']],
+    });
+    const v1: Vector3 = [0, 0, 0];
+    const v2: Vector3 = [0, 0, 0];
+
+    expect(coord.map(v1)).toEqual(v2);
+    expect(coord.map([1, 1, 1])).toEqual([300, 150, 0]);
+  });
+});

--- a/__tests__/unit/transforms/scale3D.spec.ts
+++ b/__tests__/unit/transforms/scale3D.spec.ts
@@ -1,0 +1,35 @@
+import { Coordinate3D } from '../../../src';
+
+describe('scale3D', () => {
+  test('scale3D() applies translate transformation for vector2', () => {
+    const coord = new Coordinate3D();
+    coord.transform('scale3D', 2, 4, 2);
+
+    expect(coord.map([0.1, 0.2, 0.1])).toEqual([0.2, 0.8, 0.2]);
+    expect(coord.map([-0.1, -0.2, -0.1])).toEqual([-0.2, -0.8, -0.2]);
+    expect(coord.invert([0.2, 0.8, 0.2])).toEqual([0.1, 0.2, 0.1]);
+    expect(coord.invert([-0.2, -0.8, -0.2])).toEqual([-0.1, -0.2, -0.1]);
+  });
+
+  test('scale3D() can be applied after cartesian transformation', () => {
+    const coord = new Coordinate3D();
+    coord.transform('cartesian3D');
+    coord.transform('scale3D', 2, 4, 2);
+
+    expect(coord.map([0.1, 0.2, 0.1])).toEqual([60, 120, 30]);
+    expect(coord.map([-0.1, -0.2, -0.1])).toEqual([-60, -120, -30]);
+    expect(coord.invert([60, 120, 30])).toEqual([0.1, 0.2, 0.1]);
+    expect(coord.invert([-60, -120, -30])).toEqual([-0.1, -0.2, -0.1]);
+  });
+
+  test('scale3D() can be applied before cartesian transformation', () => {
+    const coord = new Coordinate3D();
+    coord.transform('scale3D', 2, 4, 2);
+    coord.transform('cartesian3D');
+
+    expect(coord.map([0.1, 0.2, 0.1])).toEqual([60, 120, 30]);
+    expect(coord.map([-0.1, -0.2, -0.1])).toEqual([-60, -120, -30]);
+    expect(coord.invert([60, 120, 30])).toEqual([0.1, 0.2, 0.1]);
+    expect(coord.invert([-60, -120, -30])).toEqual([-0.1, -0.2, -0.1]);
+  });
+});

--- a/__tests__/unit/transforms/translate3D.spec.ts
+++ b/__tests__/unit/transforms/translate3D.spec.ts
@@ -1,0 +1,30 @@
+import { Coordinate3D } from '../../../src';
+
+describe('Translate3D', () => {
+  test('translate3D() applies translate transformation for vector3', () => {
+    const coord = new Coordinate3D();
+    coord.transform('translate3D', 0.1, 0.2, 0.3);
+    const [v1, v2, v3] = coord.map([0, 0, 0]);
+    expect(v1).toBeCloseTo(0.1);
+    expect(v2).toBeCloseTo(0.2);
+    expect(v3).toBeCloseTo(0.3);
+  });
+
+  test('translate3D() can be applied before cartesian transformation', () => {
+    const coord = new Coordinate3D();
+    coord.transform('translate3D', 0.1, 0.1, 0.1);
+    coord.transform('cartesian3D');
+    const [v1, v2, v3] = coord.map([0, 0, 0]);
+    expect(v1).toBeCloseTo(30);
+    expect(v2).toBeCloseTo(15);
+    expect(v3).toBeCloseTo(15);
+  });
+
+  test('translate3D() can be applied after cartesian transformation', () => {
+    const coord = new Coordinate3D();
+    coord.transform('cartesian3D');
+    coord.transform('translate3D', 10, 20, 30);
+    expect(coord.map([0, 0, 0])).toEqual([10, 20, 30]);
+    expect(coord.invert([10, 20, 30])).toEqual([0, 0, 0]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -29,13 +29,14 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@antv/matrix-util": "^3.0.4",
-    "@antv/scale": "^0.4.0",
+    "gl-matrix": "^3.4.3",
+    "@antv/scale": "^0.4.12",
     "@antv/util": "^2.0.13"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@rollup/plugin-commonjs": "^20.0.0",
+    "@types/gl-matrix": "^2.4.5",
     "@types/jest": "^26.0.20",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
@@ -53,7 +54,7 @@
     "rollup-plugin-typescript": "^1.0.1",
     "rollup-plugin-uglify": "^6.0.4",
     "ts-jest": "^26.5.1",
-    "typescript": "^4.1.5"
+    "typescript": "4.8.3"
   },
   "jest": {
     "preset": "ts-jest",
@@ -73,12 +74,12 @@
   "limit-size": [
     {
       "path": "dist/coordinate.min.js",
-      "limit": "10 Kb",
+      "limit": "12 Kb",
       "gzip": true
     },
     {
       "path": "dist/coordinate.min.js",
-      "limit": "25 Kb"
+      "limit": "30 Kb"
     }
   ],
   "husky": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     },
     {
       "path": "dist/coordinate.min.js",
-      "limit": "30 Kb"
+      "limit": "40 Kb"
     }
   ],
   "husky": {

--- a/src/coordinate.ts
+++ b/src/coordinate.ts
@@ -172,7 +172,7 @@ export class Coordinate {
     for (const [name, ...args] of transformations) {
       const createTransformer = this.transformers[name];
       if (createTransformer) {
-        const { x, y, z, width, height, depth } = this.options;
+        const { x, y, width, height } = this.options;
         const transformer = createTransformer([...args], x, y, width, height);
         if (isMatrix(transformer)) {
           // 如果当前变换是矩阵变换，那么先保存下来

--- a/src/coordinate3D.ts
+++ b/src/coordinate3D.ts
@@ -1,73 +1,39 @@
 import { deepMix, identity } from '@antv/util';
-import { mat3, vec3 } from 'gl-matrix';
-import { Options, Transformation, Transform, Transformer, Matrix3, Vector3, Vector2, Vector } from './type';
-import { compose, isMatrix, extend } from './utils';
-import {
-  cartesian,
-  translate,
-  custom,
-  matrix,
-  polar,
-  transpose,
-  scale,
-  shearX,
-  shearY,
-  reflect,
-  reflectX,
-  reflectY,
-  rotate,
-  helix,
-  parallel,
-  fisheye,
-  fisheyeX,
-  fisheyeY,
-  fisheyeCircular,
-} from './transforms';
+import { mat4, vec4 } from 'gl-matrix';
+import { Vector3, Vector, Transform3D, Options3D, Transformation3D, Transformer3D, Matrix4, Vector4 } from './type';
+import { compose, isMatrix, extend3D } from './utils';
+import { cartesian3D, translate3D, scale3D } from './transforms';
 
-export class Coordinate {
+export class Coordinate3D {
   // 所有变换合成后的函数
-  private output: Transform;
+  private output: Transform3D;
 
   // 所有变换合成后的逆函数
-  private input: Transform;
+  private input: Transform3D;
 
   // 当前的选项
-  private options: Options = {
+  private options: Options3D = {
     x: 0,
     y: 0,
+    z: 0,
     width: 300,
     height: 150,
+    depth: 150,
     transformations: [],
   };
 
   // 当前可以使用的变换
   private transformers = {
-    cartesian,
-    translate,
-    custom,
-    matrix,
-    polar,
-    transpose,
-    scale,
-    'shear.x': shearX,
-    'shear.y': shearY,
-    reflect,
-    'reflect.x': reflectX,
-    'reflect.y': reflectY,
-    rotate,
-    helix,
-    parallel,
-    fisheye,
-    'fisheye.x': fisheyeX,
-    'fisheye.y': fisheyeY,
-    'fisheye.circular': fisheyeCircular,
+    cartesian3D,
+    translate3D,
+    scale3D,
   };
 
   /**
    * Create a new Coordinate Object.
    * @param options Custom options
    */
-  constructor(options?: Partial<Options>) {
+  constructor(options?: Partial<Options3D>) {
     this.update(options);
   }
 
@@ -75,7 +41,7 @@ export class Coordinate {
    * Update options and inner state.
    * @param options Options to be updated
    */
-  public update(options: Partial<Options>) {
+  public update(options: Partial<Options3D>) {
     this.options = deepMix({}, this.options, options);
     this.recoordinate();
   }
@@ -85,7 +51,7 @@ export class Coordinate {
    * @returns Coordinate
    */
   public clone() {
-    return new Coordinate(this.options);
+    return new Coordinate3D(this.options);
   }
 
   /**
@@ -107,20 +73,20 @@ export class Coordinate {
 
   /**
    * Returns the size of the bounding box of the coordinate.
-   * @returns [width, height]
+   * @returns [width, height, depth]
    */
-  public getSize(): [number, number] {
-    const { width, height } = this.options;
-    return [width, height];
+  public getSize(): [number, number, number] {
+    const { width, height, depth } = this.options;
+    return [width, height, depth];
   }
 
   /**
    * Returns the center of the bounding box of the coordinate.
    * @returns [centerX, centerY, centerZ]
    */
-  public getCenter(): [number, number] {
-    const { x, y, width, height } = this.options;
-    return [(x * 2 + width) / 2, (y * 2 + height) / 2];
+  public getCenter(): [number, number, number] {
+    const { x, y, z, width, height, depth } = this.options;
+    return [(x * 2 + width) / 2, (y * 2 + height) / 2, (z * 2 + depth) / 2];
   }
 
   /**
@@ -128,7 +94,7 @@ export class Coordinate {
    * @param args transform type and params
    * @returns Coordinate
    */
-  public transform(...args: Transformation) {
+  public transform(...args: Transformation3D) {
     const { transformations } = this.options;
     this.update({
       transformations: [...transformations, [...args]],
@@ -138,19 +104,19 @@ export class Coordinate {
 
   /**
    * Apples transformations for the current vector.
-   * @param vector original vector2
-   * @returns transformed vector2
+   * @param vector original vector3
+   * @returns transformed vector3
    */
-  public map(vector: Vector2 | Vector) {
+  public map(vector: Vector3 | Vector) {
     return this.output(vector);
   }
 
   /**
    * Apples invert transformations for the current vector.
-   * @param vector transformed vector2
-   * @param vector original vector2
+   * @param vector transformed vector3
+   * @param vector original vector3
    */
-  public invert(vector: Vector2 | Vector) {
+  public invert(vector: Vector3 | Vector) {
     return this.input(vector);
   }
 
@@ -164,16 +130,18 @@ export class Coordinate {
   // 处理过程中需要把连续的矩阵变换合成一个变换函数，然后在和其他变换函数合成最终的变换函数
   private compose(invert = false) {
     const transformations = invert ? [...this.options.transformations].reverse() : this.options.transformations;
-    const getter = invert ? (d: Transformer) => d.untransform : (d: Transformer) => d.transform;
+    const getter = invert ? (d: Transformer3D) => d.untransform : (d: Transformer3D) => d.transform;
     const matrixes = [];
     const transforms = [];
-    const add = (transform: Transform, extended = true) => transforms.push(extended ? extend(transform) : transform);
+    const add = (transform: Transform3D, extended = true) =>
+      transforms.push(extended ? extend3D(transform) : transform);
 
     for (const [name, ...args] of transformations) {
       const createTransformer = this.transformers[name];
       if (createTransformer) {
         const { x, y, z, width, height, depth } = this.options;
-        const transformer = createTransformer([...args], x, y, width, height);
+        const transformer = createTransformer([...args], x, y, z, width, height, depth);
+
         if (isMatrix(transformer)) {
           // 如果当前变换是矩阵变换，那么先保存下来
           matrixes.push(transformer);
@@ -184,8 +152,8 @@ export class Coordinate {
             add(transform);
             matrixes.splice(0, matrixes.length);
           }
-          const transform = getter(transformer) || identity;
-          add(transform, name !== 'parallel'); // 对于非平行坐标系的变换需要扩展
+          const transform = getter(transformer as Transformer3D) || identity;
+          add(transform, true);
         }
       }
     }
@@ -196,21 +164,22 @@ export class Coordinate {
       add(transform);
     }
 
-    return compose<Vector2 | Vector>(...transforms);
+    return compose<Vector3 | Vector>(...transforms);
   }
 
   // 将连续的矩阵的运算合成一个变换函数
-  private createMatrixTransform(matrixes: Matrix3[], invert: boolean): Transform {
-    const matrix = mat3.create();
+  private createMatrixTransform(matrixes: Matrix4[], invert: boolean): Transform3D {
+    const matrix = mat4.create();
     if (invert) matrixes.reverse();
-    matrixes.forEach((m) => mat3.mul(matrix, matrix, m));
+    matrixes.forEach((m) => mat4.mul(matrix, matrix, m));
     if (invert) {
-      mat3.invert(matrix, mat3.clone(matrix));
+      mat4.invert(matrix, mat4.clone(matrix));
     }
-    return (vector: Vector2): Vector2 => {
-      const vector3: Vector3 = [vector[0], vector[1], 1];
-      vec3.transformMat3(vector3, vector3, matrix);
-      return [vector3[0], vector3[1]];
+    return (vector: Vector3): Vector3 => {
+      const vector4: Vector4 = [vector[0], vector[1], vector[2], 1];
+
+      vec4.transformMat4(vector4, vector4, matrix);
+      return [vector4[0], vector4[1], vector4[2]];
     };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export type { Options, Vector2, Vector, Transformation, Matrix3 } from './type';
+export type { Options, Vector, Transformation, Matrix3, Vector2, Vector3 } from './type';
 export { Coordinate } from './coordinate';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export type { Options, Vector, Transformation, Matrix3, Vector2, Vector3 } from './type';
 export { Coordinate } from './coordinate';
+export { Coordinate3D } from './coordinate3D';

--- a/src/transforms/cartesian.ts
+++ b/src/transforms/cartesian.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Linear } from '@antv/scale';
-import { Vector2, CreateTransformer } from '../type';
+import { CreateTransformer, Vector2 } from '../type';
 
 /**
  * Maps normalized value to the bounding box of coordinate.

--- a/src/transforms/cartesian3D.ts
+++ b/src/transforms/cartesian3D.ts
@@ -1,0 +1,26 @@
+import { Linear } from '@antv/scale';
+import { Vector3, CreateTransformer } from '../type';
+
+// @ts-ignore
+export const cartesian3D: CreateTransformer = (params, x, y, z, width, height, depth) => {
+  const sx = new Linear({
+    range: [x, x + width],
+  });
+  const sy = new Linear({
+    range: [y, y + height],
+  });
+  const sz = new Linear({
+    range: [z, z + depth],
+  });
+
+  return {
+    transform(vector: Vector3) {
+      const [v1, v2, v3] = vector;
+      return [sx.map(v1), sy.map(v2), sz.map(v3)];
+    },
+    untransform(vector: Vector3) {
+      const [v1, v2, v3] = vector;
+      return [sx.invert(v1), sy.invert(v2), sz.invert(v3)];
+    },
+  };
+};

--- a/src/transforms/cartesian3D.ts
+++ b/src/transforms/cartesian3D.ts
@@ -1,8 +1,7 @@
 import { Linear } from '@antv/scale';
-import { Vector3, CreateTransformer } from '../type';
+import { Vector3, CreateTransformer3D } from '../type';
 
-// @ts-ignore
-export const cartesian3D: CreateTransformer = (params, x, y, z, width, height, depth) => {
+export const cartesian3D: CreateTransformer3D = (params, x, y, z, width, height, depth) => {
   const sx = new Linear({
     range: [x, x + width],
   });

--- a/src/transforms/index.ts
+++ b/src/transforms/index.ts
@@ -1,6 +1,5 @@
 export { translate } from './translate';
 export { cartesian } from './cartesian';
-export { cartesian3D } from './cartesian3D';
 export { custom } from './custom';
 export { matrix } from './matrix';
 export { polar } from './polar';
@@ -12,3 +11,7 @@ export { helix } from './helix';
 export { parallel } from './parallel';
 export { shearX, shearY } from './shear';
 export { fisheye, fisheyeX, fisheyeY, fisheyeCircular } from './fisheye';
+
+export { cartesian3D } from './cartesian3D';
+export { translate3D } from './translate3D';
+export { scale3D } from './scale3D';

--- a/src/transforms/index.ts
+++ b/src/transforms/index.ts
@@ -1,5 +1,6 @@
 export { translate } from './translate';
 export { cartesian } from './cartesian';
+export { cartesian3D } from './cartesian3D';
 export { custom } from './custom';
 export { matrix } from './matrix';
 export { polar } from './polar';

--- a/src/transforms/rotate.ts
+++ b/src/transforms/rotate.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { mat3 } from '@antv/matrix-util';
+import { mat3 } from 'gl-matrix';
 import { CreateTransformer } from '../type';
 
 /**

--- a/src/transforms/scale.ts
+++ b/src/transforms/scale.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { mat3 } from '@antv/matrix-util';
+import { mat3 } from 'gl-matrix';
 import { CreateTransformer } from '../type';
 
 /**

--- a/src/transforms/scale3D.ts
+++ b/src/transforms/scale3D.ts
@@ -1,0 +1,18 @@
+import { mat4 } from 'gl-matrix';
+import { CreateTransformer3D } from '../type';
+
+/**
+ * Apply scale transformation for current vector.
+ * @param params [sx, sy, sz]
+ * @param x x of the the bounding box of coordinate
+ * @param y y of the the bounding box of coordinate
+ * @param z z of the the bounding box of coordinate
+ * @param width width of the the bounding box of coordinate
+ * @param height height of the the bounding box of coordinate
+ * @param depth depth of the the bounding box of coordinate
+ * @returns transformer
+ */
+export const scale3D: CreateTransformer3D = (params, x, y, z, width, height, depth) => {
+  const [sx, sy, sz] = params as number[];
+  return mat4.fromScaling(mat4.create(), [sx, sy, sz]);
+};

--- a/src/transforms/translate.ts
+++ b/src/transforms/translate.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { mat3 } from '@antv/matrix-util';
+import { mat3 } from 'gl-matrix';
 import { CreateTransformer } from '../type';
 
 /**

--- a/src/transforms/translate3D.ts
+++ b/src/transforms/translate3D.ts
@@ -1,0 +1,18 @@
+import { mat4 } from 'gl-matrix';
+import { CreateTransformer3D } from '../type';
+
+/**
+ * Apply translate transformation for current vector.
+ * @param params [tx, ty, tz]
+ * @param x x of the the bounding box of coordinate
+ * @param y y of the the bounding box of coordinate
+ * @param z z of the the bounding box of coordinate
+ * @param width width of the the bounding box of coordinate
+ * @param height height of the the bounding box of coordinate
+ * @param depth depth of the the bounding box of coordinate
+ * @returns transformer
+ */
+export const translate3D: CreateTransformer3D = (params, x, y, z, width, height, depth) => {
+  const [tx, ty, tz] = params as number[];
+  return mat4.fromTranslation(mat4.create(), [tx, ty, tz]);
+};

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,10 +1,17 @@
-import { vec3, mat3 } from 'gl-matrix';
+import { vec3, mat3, mat4, vec4 } from 'gl-matrix';
 
 export type TransformCallback = (x: number, y: number, width: number, height: number) => Transformer;
+export type Transform3DCallback = (
+  x: number,
+  y: number,
+  z: number,
+  width: number,
+  height: number,
+  depth: number,
+) => Transformer3D;
 
 type Translate = ['translate', number, number];
 type Cartesian = ['cartesian'];
-type Cartesian3D = ['cartesian3D'];
 type Custom = ['custom', TransformCallback];
 type Matrix = ['matrix', Matrix3];
 type Polar = ['polar', number, number, number, number];
@@ -23,10 +30,13 @@ type FisheyeX = ['fisheye.x', number, number, boolean?];
 type FisheyeY = ['fisheye.y', number, number, boolean?];
 type FisheyeCircular = ['fisheye.circular', number, number, number, number, boolean?];
 
+type Cartesian3D = ['cartesian3D'];
+type Translate3D = ['translate3D', number, number, number];
+type Scale3D = ['scale3D', number, number, number];
+
 export type Transformation =
   | Translate
   | Cartesian
-  | Cartesian3D
   | Custom
   | Matrix
   | Polar
@@ -44,30 +54,44 @@ export type Transformation =
   | FisheyeX
   | FisheyeY
   | FisheyeCircular;
+export type Transformation3D = Cartesian3D | Translate3D | Scale3D;
 
 export type Options = {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  transformations?: Transformation[];
+};
+export type Options3D = {
   x?: number;
   y?: number;
   z?: number;
   width?: number;
   height?: number;
   depth?: number;
-  transformations?: Transformation[];
+  transformations?: Transformation3D[];
 };
 
 export type Vector2 = [number, number];
-
 export type Vector3 = vec3;
+export type Vector4 = vec4;
 
 export type Vector = number[];
 
 export type Matrix3 = mat3;
+export type Matrix4 = mat4;
 
 export type Transform = (vector: Vector2 | Vector) => Vector2 | Vector;
+export type Transform3D = (vector: Vector3 | Vector) => Vector3 | Vector;
 
 export type Transformer = {
   transform?: Transform;
   untransform?: Transform;
+};
+export type Transformer3D = {
+  transform?: Transform3D;
+  untransform?: Transform3D;
 };
 
 export type CreateTransformer = (
@@ -77,3 +101,12 @@ export type CreateTransformer = (
   width: number,
   height: number,
 ) => Transformer | Matrix3;
+export type CreateTransformer3D = (
+  params: number[] | (number | boolean)[] | [TransformCallback] | [Matrix3],
+  x: number,
+  y: number,
+  z: number,
+  width: number,
+  height: number,
+  depth: number,
+) => Transformer3D | Matrix4;

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,9 +1,10 @@
-import { vec3, mat3 } from '@antv/matrix-util';
+import { vec3, mat3 } from 'gl-matrix';
 
 export type TransformCallback = (x: number, y: number, width: number, height: number) => Transformer;
 
 type Translate = ['translate', number, number];
 type Cartesian = ['cartesian'];
+type Cartesian3D = ['cartesian3D'];
 type Custom = ['custom', TransformCallback];
 type Matrix = ['matrix', Matrix3];
 type Polar = ['polar', number, number, number, number];
@@ -25,6 +26,7 @@ type FisheyeCircular = ['fisheye.circular', number, number, number, number, bool
 export type Transformation =
   | Translate
   | Cartesian
+  | Cartesian3D
   | Custom
   | Matrix
   | Polar
@@ -46,8 +48,10 @@ export type Transformation =
 export type Options = {
   x?: number;
   y?: number;
+  z?: number;
   width?: number;
   height?: number;
+  depth?: number;
   transformations?: Transformation[];
 };
 

--- a/src/utils/extend.ts
+++ b/src/utils/extend.ts
@@ -1,4 +1,4 @@
-import { Transform, Vector } from '../type';
+import { Transform, Transform3D, Vector } from '../type';
 
 // 对普通的变换函数进行扩展
 // 对于长度大于2的向量，两两为一个点的 x 和 y 坐标
@@ -15,7 +15,7 @@ export function extend(transform: Transform) {
   };
 }
 
-export function extend3D(transform: Transform) {
+export function extend3D(transform: Transform3D) {
   return (vector: Vector) => {
     const v = [];
     for (let i = 0; i < vector.length - 1; i += 3) {

--- a/src/utils/extend.ts
+++ b/src/utils/extend.ts
@@ -14,3 +14,15 @@ export function extend(transform: Transform) {
     return v;
   };
 }
+
+export function extend3D(transform: Transform) {
+  return (vector: Vector) => {
+    const v = [];
+    for (let i = 0; i < vector.length - 1; i += 3) {
+      const from = [vector[i], vector[i + 1], vector[i + 2]];
+      const to = transform(from);
+      v.push(...to);
+    }
+    return v;
+  };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { compose } from './compose';
 export { isMatrix } from './isMatrix';
-export { extend } from './extend';
+export { extend, extend3D } from './extend';
 export { adjustAngle } from './adjustAngle';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "lib": ["dom", "esnext"],
     "skipLibCheck": true,
     "sourceRoot": "src",
-    "baseUrl": "src"
+    "baseUrl": "src",
+    "downlevelIteration": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
新增加了一种 transform，以便支持 3D 场景：

```js
const coord = new Coordinate({
  transformations: [['cartesian3D']],
  z: 0, // 可选
  depth: 100, // 可选
});
```

暂不支持和其他 transform 进行 compose，因为参数数目不同（多出来了 z 和 depth）。
测试用例已补充。

另外移除了 `@antv/matrix-util`，替换成了 `gl-matrix`，前者其实也就是 export 了后者。